### PR TITLE
fix: display problem with follow-up images on the 'about' page

### DIFF
--- a/source/css/_custom/about/about.css
+++ b/source/css/_custom/about/about.css
@@ -556,6 +556,8 @@ body[data-type="about"] #web_bg {
 .author-content-item.comic-content .comic-item .comic-item-cover img {
   height: 100%;
   transition: 0.8s;
+  max-width: none;
+  border-radius: 0px;
 }
 .author-content-item.comic-content::after {
   box-shadow: 0 -48px 203px 11px #fbe9b8 inset;


### PR DESCRIPTION
![CleanShot 2023-04-14 at 22 49 25@2x](https://user-images.githubusercontent.com/92566148/232078461-146596ba-ea24-4b0e-87c4-18d7ac5bd1b3.png)
![CleanShot 2023-04-14 at 22 53 55@2x](https://user-images.githubusercontent.com/92566148/232079154-e80e2305-0c09-4937-ab86-82a82578a45c.png)
