### PR TITLE
fix: if the reward is not enabled, the reward-link mode is not aligned

### DIFF
--- a/source/css/_custom/aside/aside.css
+++ b/source/css/_custom/aside/aside.css
@@ -51,7 +51,7 @@ span.card-archive-list-count {
   font-weight: 700;
 }
 .card-archive-list-date {
-  font-size: 14px;
+  font-size: 13px;
   opacity: 0.6;
 }
 li.card-archive-list-item {

--- a/source/css/_layout/reward.styl
+++ b/source/css/_layout/reward.styl
@@ -23,6 +23,7 @@
     background: var(--anzhiyu-red);
     color: var(--anzhiyu-white);
     padding: 0;
+    margin-right: 0.5rem;
     width: 126px;
     height: 40px;
     line-height: 39px;
@@ -113,7 +114,6 @@
   line-height: 39px;
   box-shadow: var(--anzhiyu-shadow-green);
   border-radius: 8px;
-  margin-left: 0.5rem;
   text-align: center;
   transition: 0.3s;
   &:hover


### PR DESCRIPTION
>如果未开启打赏功能，则会导致`reward-link mode`不对齐

![CleanShot 2023-04-15 at 15 20 34@2x](https://user-images.githubusercontent.com/92566148/232195637-e1b5c5f5-ac57-4cb9-ad51-dc558fe1092d.png)
![CleanShot 2023-04-15 at 15 20 59@2x](https://user-images.githubusercontent.com/92566148/232195635-12e3d184-127d-42f7-939a-93867c06b316.png)