### PR TITLE
fix: the categoryBar style on mobile

### DIFF
--- a/source/css/_custom/categoryBar/categoryBar.css
+++ b/source/css/_custom/categoryBar/categoryBar.css
@@ -82,12 +82,4 @@
   [data-theme="dark"] #category-bar.category-bar {
     background: var(--anzhiyu-black);
   }
-  #category-bar.category-bar:hover {
-    border: none;
-    box-shadow: none;
-  }
-  #category-bar {
-    border: none;
-    border-radius: 0px;
-  }
 }


### PR DESCRIPTION
图一到图二。当然亮色模式下没什么问题，但是暗色下 categoryBar 的背景颜色与主体不同，也可以只修改暗色模式下的背景颜色。
![IMG_2777](https://user-images.githubusercontent.com/92566148/233280794-bbf75828-7105-4db7-867b-d101a38d9cc0.PNG)
![IMG_2778](https://user-images.githubusercontent.com/92566148/233280817-929f041a-5c61-4e66-98b8-a80924181f82.PNG)
