### PR TITLE
调整自定义文字位置

### DIFF
--- a/layout/includes/footer.pug
+++ b/layout/includes/footer.pug
@@ -42,10 +42,10 @@
     #workboard
       img(src=`${work_img}`, alt=`${work_description}`, title=`${work_description}`, class="workSituationImg boardsign")
       #runtimeTextTip
+  if theme.footer.custom_text
+    .footer_custom_text!=`${theme.footer.custom_text}`
   if theme.footer.bdageitem
     p#ghbdages
       each item in theme.footer.bdageitem
         a.github-badge(target='_blank' href=item.link style='margin-inline:5px' data-title=item.message title=item.message)
           img(src=item.shields alt=item.message)
-  if theme.footer.custom_text
-    .footer_custom_text!=`${theme.footer.custom_text}`


### PR DESCRIPTION
将自定义文字custom_text的位置移到勋章bdageitem之前，运行时间runtime之后，使之更合理
以下为示例
配置文件截取
``` yaml
footer:
  owner:
    enable: true
    since: 2022
  custom_text: 测试 - Copyright © 2023 HiPeach Inc. All Rights Reserved. - 自定义文字
  runtime:
    enable: true
    ...
```
自定义文字内容为 `测试 - Copyright © 2023 HiPeach Inc. All Rights Reserved. - 自定义文字`
更改之前图片示例
![更改之前图片示例](https://github.com/anzhiyu-c/hexo-theme-anzhiyu/assets/84276185/3b9dcb4a-b7eb-4f28-9024-d70d51979277)
更改之后图片示例
![QQ截图20230614220104](https://github.com/anzhiyu-c/hexo-theme-anzhiyu/assets/84276185/363d9c83-2d12-42c4-9e9b-f08ffb1a8b9e)
