### PR TITLE
feat: 支持手机端的侧边栏由博主自定义配置背景颜色

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -705,6 +705,7 @@ theme_color:
   scrollbar_color: "var(--anzhiyu-scrollbar)"
   meta_theme_color_light: "#f7f9fe"
   meta_theme_color_dark: "#18171d"
+  inside_sidebar_background: "#607d8b" # @since 1.5.4 支持手机端侧边栏可定制颜色
 
 # 文章h2添加分隔线
 h2Divider: false

--- a/source/css/var.styl
+++ b/source/css/var.styl
@@ -103,7 +103,7 @@ $tag-hide-toggle-bg = #f0f0f0
 $preloader-bg = #37474f
 $preloader-word-color = #fff
 // sidebar
-$inside-sidebar-background = #607d8b;
+$inside-sidebar-background = $themeColorEnable && hexo-config('theme_color.inside_sidebar_background') ? convert(hexo-config('inside_sidebar_background')) : #607d8b;
 // rightside
 $rightside-bottom = hexo-config('rightside-bottom') ? convert(hexo-config('rightside-bottom')) : 40px
 // fireworks

--- a/source/css/var.styl
+++ b/source/css/var.styl
@@ -103,7 +103,7 @@ $tag-hide-toggle-bg = #f0f0f0
 $preloader-bg = #37474f
 $preloader-word-color = #fff
 // sidebar
-$inside-sidebar-background = $themeColorEnable && hexo-config('theme_color.inside_sidebar_background') ? convert(hexo-config('inside_sidebar_background')) : #607d8b;
+$inside-sidebar-background = $themeColorEnable && hexo-config('theme_color.inside_sidebar_background') ? convert(hexo-config('theme_color.inside_sidebar_background')) : #607d8b;
 // rightside
 $rightside-bottom = hexo-config('rightside-bottom') ? convert(hexo-config('rightside-bottom')) : 40px
 // fireworks


### PR DESCRIPTION
1. 增加自定义配置手机端侧边栏
2. 增加示例配置，且默认值为原有的#607d8b，不会影响之前存量用户的效果
3. 用户如需定制只需修改默认配置的inside_sidebar_background即可

已完成测试，放心使用！