### PR TITLE
feat: 修改申请友链按钮变成addFriendPlaceholder有配置且twikoo的envId不能为空

### DIFF
--- a/layout/includes/page/flink.pug
+++ b/layout/includes/page/flink.pug
@@ -10,7 +10,7 @@
             a.banner-button.secondary.no-text-decoration(onclick="friendChainRandomTransmission()")
               i.anzhiyufont.anzhiyu-icon-paper-plane1
               span.banner-button-text 随机访问
-          if theme.comment_barrage_config.enable && theme.comments.use == 'Twikoo'
+          if theme.linkPageTop.addFriendPlaceholder && theme.comments.use == 'Twikoo' && theme.twikoo.envId
             a.banner-button.no-text-decoration(onclick="anzhiyu.addFriendLink()")
               i.anzhiyufont.anzhiyu-icon-arrow-circle-right
               span.banner-button-text 申请友链

--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -642,16 +642,20 @@ const anzhiyu = {
   addFriendLink() {
     var input = document.getElementsByClassName("el-textarea__inner")[0];
     if (!input) return;
-    let evt = document.createEvent("HTMLEvents");
-    evt.initEvent("input", true, true);
+    const evt = new Event("input", { cancelable: true, bubbles: true });
     const defaultPlaceholder =
       "昵称（请勿包含博客等字样）：\n网站地址（要求博客地址，请勿提交个人主页）：\n头像图片url（请提供尽可能清晰的图片，我会上传到我自己的图床）：\n描述：\n站点截图（可选）：\n";
-    input.value = GLOBAL_CONFIG.linkPageTop.addFriendPlaceholder
-      ? GLOBAL_CONFIG.linkPageTop.addFriendPlaceholder
-      : defaultPlaceholder;
+    input.value = this.getConfigIfPresent(GLOBAL_CONFIG.linkPageTop, 'addFriendPlaceholder', defaultPlaceholder)
     input.dispatchEvent(evt);
     input.focus();
     input.setSelectionRange(-1, -1);
+  },
+  // 获取配置，如果为空则返回默认值
+  getConfigIfPresent: function (config, configKey, defaultValue) {
+    if (!config) return defaultValue;
+    if (!config.hasOwnProperty(configKey)) return defaultValue;
+    if (!config[configKey]) return defaultValue;
+    return config[configKey];
   },
   //切换音乐播放状态
   musicToggle: function (changePaly = true) {


### PR DESCRIPTION
调整逻辑：
1.将addFriendPlaceholder调整到了linkPageTop确实更合理，原来导向的申请友链按钮逻辑进行调整，原先是通过留言弹幕是否有开启来判断的
2.修复可能会出现的undefined问题

修改内容：
1.增加通过linkPageTop.addFriendPlaceholder和twikoo.envId同时存在且comments.use配置中包含twikoo/i时
2.utils修复event在deno浏览器下下不可用问题
3.utils修复取配置先出现undefined问题

测试用例：
引入到自己页面中已测试完毕，可放心使用！