### PR TITLE
fix: 移动端小屏幕下还是有溢出的现象，修改成min-height进行

### DIFF
--- a/source/css/_page/homepage.styl
+++ b/source/css/_page/homepage.styl
@@ -136,7 +136,7 @@
 
       +maxWidth768()
         width: 100%
-        height: 140px;
+        min-height: 140px;
       &.no-cover
         width: 100%
 


### PR DESCRIPTION
<img width="303" alt="3f1a63b7c267035a9318144b0d9b8bb" src="https://github.com/anzhiyu-c/hexo-theme-anzhiyu/assets/22519817/c179a91e-6d00-4b9e-ac92-f3f49b5bfaa6">
中小屏幕下仍然有溢出，进行修复完成.