### PR TITLE
修复轮播图首次加载空白问题

### DIFF
--- a/layout/includes/top/top.pug
+++ b/layout/includes/top/top.pug
@@ -124,6 +124,10 @@ if home_top_config.enable
         },
       });
 
+      window.addEventListener("load", function () {
+        swiper.update();
+      });
+
       var comtainer = document.getElementById("swiper_container");
       if (comtainer !== null) {
         comtainer.onmouseenter = function () {


### PR DESCRIPTION
首页 swiper 轮播在首次加载时偶尔出现空白，触发条件：
1. 首次打开网站
2. 清空缓存并进行硬刷新
3. 在网络中禁用缓存刷新