### PR TITLE
修改了footer对copyright的判断

### DIFF
--- a/layout/includes/footer.pug
+++ b/layout/includes/footer.pug
@@ -73,7 +73,8 @@ if theme.footer.footerBar && theme.footer.footerBar.enable
               .copyright!= `&copy;${theme.footer.owner.since} - ${nowYear} By `
                 a.footer-bar-link(href=url_for(authorLink) title=config.author target="_blank")=config.author
             else
-              .copyright!= `&copy;${nowYear} By ${config.author} `
+              .copyright!= `&copy;${nowYear} By `
+                a.footer-bar-link(href=url_for(authorLink) title=config.author target="_blank")=config.author
         #footer-type-tips
         if theme.footer.footerBar && theme.footer.footerBar.subTitle && theme.footer.footerBar.subTitle.enable
           .js-pjax


### PR DESCRIPTION
修改前：footer设置成当前年份（如主题文件since: 2023），copyright的名字无超链接以及与打字效果无间隔。修改后，与其他年份的样式保持一致