### PR TITLE
新增member友链卡片样式

### DIFF
--- a/layout/includes/page/flink.pug
+++ b/layout/includes/page/flink.pug
@@ -122,4 +122,48 @@
                   else
                     img.cf-friends-avatar.no-lightbox(src=url_for(item.avatar) onerror=`this.onerror=null;this.src='` + url_for(theme.error_img.flink) + `'` alt='cover' )
                   span.flink-sitename.cf-friends-name= item.name
+                  
+        else if i.flink_style === 'member'
+          .links-friends
+            each item in i.link_list
+              - let tag = item.tag || ""
+              - let genre = item.genre || ""
+              - let data = item.data || ""
+
+              - let playerBgSrc = genre === 'svip' ? "https://yanyuplus.cn/img/heijinV.d5ce1d07.png" : genre === 'vip' ? "https://www.blatr.cn/images/vip/bojinV.png" : ""
+              - let badgeSrc = genre === 'svip' ? "https://www.blatr.cn/images/vip/hjhg.png" : genre === 'vip' ? "https://www.blatr.cn/images/vip/zjzs.png" : ""
+              - let className = genre === 'svip' ? "" : genre === 'vip' ? "player-content-zs" : "player-content-pv"
+              - let imgSrc = genre === 'svip' && tag ? "https://www.blatr.cn/images/vip/yzbk.png" : genre === 'vip' && tag ? "https://www.blatr.cn/images/vip/jinfen.png" : ""
+              - let fontColor = genre === 'svip' ? "f-w-name-ph" : genre === 'vip' ? "f-w-name-zx" : "f-w-name-pv"
+              - let album = genre === 'svip' ? "album-cover-ph" : genre === 'vip' ? "album-cover-zx" : "album-cover-pv"
+              - let recommend = genre === 'svip' ? "f-span-recommend" : genre === 'vip' ? "interaction-label-2" : ""
+
+              .friends-item
+                .player
+                  .player-content-hg(class=`${className}`)
+                    span(class=`${recommend}`)
+                      if genre == "svip" && tag
+                        span
+                          img(src="https://www.blatr.cn/images/vip/yzbk.png", style="width: 12px",onclick="return false;")
+                        | #[=tag]
+                      else if genre == "vip" && tag
+                        span
+                          img(src="https://www.blatr.cn/images/vip/jinfen.png", style="width: 12px",onclick="return false;")
+                        | #[=tag]
+                    .player-bg
+                      img(src=`${playerBgSrc}`)
+                    .album-cover(class=`${album}`)
+                      a(href=url_for(item.link) title=item.name target="_blank")
+                        if theme.lazyload.enable
+                          img.cf-friends-avatar.no-lightbox(data-lazy-src=url_for(item.avatar) onerror=`this.onerror=null;this.src='` + url_for(theme.error_img.flink) + `'` alt=item.name )
+                        else
+                          img.cf-friends-avatar.no-lightbox(src=url_for(item.avatar) onerror=`this.onerror=null;this.src='` + url_for(theme.error_img.flink) + `'` alt=item.name )
+                    img.ava-badge(src=`${badgeSrc}`)
+                    .play-controls-name
+                      a(href=`${item.link}`,target='_blank')
+                        h4.ui.header.one-line.f-w-name-hg-1(class=`${fontColor}`, title=`${item.name}`)= item.name
+                    .play-controls-time
+                      p.one-line(class=`${fontColor}`) #[=item.data] 加入本站
+                    .play-controls-introduction
+                      p.one-line(class=`${fontColor}`, title=`${item.descr}`)= item.descr
     != page.content

--- a/source/css/_extra/flink/member.css
+++ b/source/css/_extra/flink/member.css
@@ -1,0 +1,158 @@
+.links-friends a {
+    text-decoration: none !important;
+}
+
+.player-bg img {
+    width: 110px;
+}
+
+.player-bg img,
+video {
+    max-width: 100%;
+    height: auto;
+}
+
+
+.friends-item a {
+    color: #4183c4;
+    text-decoration: none;
+}
+
+
+.f-span-recommend {
+    position: absolute;
+    padding: 0 4px;
+    background: -webkit-linear-gradient(to right, #1a2a6c, #b21f1f, #fdbb2d);
+    background: linear-gradient(to right, #1a2a6c, #b21f1f, #fdbb2d);
+    color: #fff;
+    border-radius: 8px 0 8px 0;
+    font-size: 12px;
+    line-height: 1.7em;
+}
+
+.interaction-label-2 {
+    position: absolute;
+    padding: 0 4px;
+    background-color: #fff3cb !important;
+    color: #f3b117 !important;
+    border-radius: 8px 0 8px 0;
+    font-size: 12px;
+    line-height: 1.7em;
+    
+}
+
+
+.player-bg {
+    position: absolute;
+    top: -14px;
+    right: -2px;
+    z-index: -1;
+}
+
+.player-bg img {
+    width: 110px;
+}
+
+.album-cover {
+    width: 52px;
+    height: 52px;
+    border-radius: 50%;
+    position: absolute;
+    top: 26px;
+    left: 10px;
+    overflow: hidden;
+    transition: 0.3s ease;
+}
+
+.album-cover-ph {
+    box-shadow: 0 0 0 1px #ffd38b;
+}
+
+.album-cover-zx {
+    box-shadow: 0 0 0 1px #7d49d4
+}
+
+.album-cover-pv {
+    box-shadow: 0 0 0 1px #146792
+}
+
+.f-span-recommend  img,.interaction-label-2 img {
+    display: inline-block !important;
+}
+
+.album-cover img {
+    display: block;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    padding: 4px;
+    border-radius: 50% !important;
+}
+
+.ava-badge {
+    position: absolute;
+    left: 46px;
+    top: 56px;
+    width: 16px;
+}
+
+.play-controls-name {
+    position: absolute;
+    top: 0;
+    left: 68px;
+    width: calc(100% - 178px);
+}
+
+.play-controls-name a {
+    padding: 0 !important;
+}
+
+.play-controls-time {
+    position: absolute;
+    font-size: .875rem;
+    top: 56px;
+    left: 68px;
+}
+
+.play-controls-introduction {
+    position: absolute;
+    top: 92px;
+    margin: 0 14px;
+    max-width: calc(100% - 28px);
+}
+
+.ui,
+.header {
+    border: none;
+    margin: calc(2rem - 0.14285714em) 0 1rem;
+    /* padding: 0 0; */
+    font-family: Lato, 'Helvetica Neue', Arial, Helvetica, sans-serif;
+    font-weight: 700;
+    line-height: 1.28571429em;
+    text-transform: none;
+}
+
+.f-w-name-ph {
+    color: #F2CB69 !important;
+    transition: .2s;
+}
+
+.f-w-name-zx {
+    color: #5657ba !important;
+    transition: .2s;
+}
+
+
+.f-w-name-pv {
+    color: #004a96 !important;
+    transition: .2s;
+}
+
+.one-line {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+    overflow: hidden;
+}

--- a/source/css/_page/flink.styl
+++ b/source/css/_page/flink.styl
@@ -476,3 +476,51 @@ body[data-type="link"]
           margin: 0;
           max-width: 100%;
 
+#article-container
+  .links-friends
+    margin-top: 1em;
+    display: grid;
+    grid-template-columns: repeat(auto-fill,minmax(240px,1fr));
+    column-gap: 10px;
+    min-width: 240px;
+    .friends-item
+      margin: 2px 0;
+      display: flex;
+      justify-content: space-around;
+      align-items: center;
+      height: calc(320px / 2 - 6px);
+      .player
+        position: relative;
+        z-index: 3;
+        width: 100%;
+        height: 130px;
+        border-radius: 8px;
+        .player-content-hg
+          background: linear-gradient(25deg, #000000 10%, #383838 70%, #000000 100%);
+          position: relative;
+          height: 100%;
+          border-radius: 8px;
+          z-index: 2;
+        .player-content-hg:before
+          content: "";
+          background-image: url(https://www.blatr.cn/images/vip/black-line.svg);
+          background-size: cover;
+          background-repeat: no-repeat;
+          background-position: center;
+          width: 100%;
+          height: 100%;
+          position: absolute;
+          border-radius: 8px;
+        .player-content-zs
+          background: linear-gradient(317deg, #a14fd2, #8888fc 30%, #c6bcff) !important;
+        .player-content-zs:before
+          background-image: url(https://www.blatr.cn/images/vip/purple-line.svg) !important;
+        .player-content-pv
+          background: linear-gradient(335deg, #1b8fda 10%, #6fc7e5 70%, #8bc8ef 100%) !important;
+        .player-content-pv:before
+          background-image: url(https://www.blatr.cn/images/vip/blue-line.svg) !important;
+    img
+      margin: 0 4px 0 0 !important;
+    a
+      text-decoration: none !important;
+      padding: 0 !important;


### PR DESCRIPTION
在link.yml中，flink_style选择member，在link_list:添加genre: (可选参数svip、vip)控制卡片样式，如果为空则是第三种样式，data为手动写入的添加友链日期（动态的目前不会搞）例子：
- name: 名字
   tag: 标签名
   genre: svip [样式名]
   data: '2023-09-22' [日期]
   link: 网站地址
   avatar: 网站图标
   descr: 描述