### PR TITLE
修复未开启pjax功能，首页顶部home_top-category词条无法跳转的bug

### DIFF
--- a/layout/includes/top/top.pug
+++ b/layout/includes/top/top.pug
@@ -21,7 +21,9 @@ if home_top_config.enable
         .categoryGroup
           each item in home_top_config.category
             .categoryItem(style=`box-shadow:${item.shadow}`)
-              a.categoryButton(onclick=`pjax.loadUrl("${item.path}");` href='javascript:void(0);' class=`${item.class}`)
+              - let onclick_value = theme.pjax.enable ? `pjax.loadUrl("${item.path}");` : '';
+              - let href_value = theme.pjax.enable ? 'javascript:void(0);' : `${item.path}`;
+              a.categoryButton(onclick=onclick_value href=href_value class=`${item.class}`)
                 span.categoryButtonText=item.name
                 if (item.icon.startsWith("fa"))
                   i(class=`${item.icon}`)


### PR DESCRIPTION
`_config.yml` 禁用 **pjax** 功能，会导致首页顶部的 `category` 卡片无法跳转。