### PR TITLE
修复中控台部分bug

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -882,7 +882,23 @@ translate:
 readmode: true
 
 # 中控台
-centerConsole: true
+centerConsole:
+  enable: true
+  card_tags:
+    enable: false
+    limit: 40 # if set 0 will show all
+    color: false
+    sort_order: # Don't modify the setting unless you know how it works
+    highlightTags:
+      # - Hexo
+      # - 前端
+  card_archives:
+    enable: false
+    type: monthly # yearly or monthly
+    format: MMMM YYYY # eg: YYYY年MM月
+    order: -1 # Sort of order. 1, asc for ascending; -1, desc for descending
+    limit: 8 # if set 0 will show all
+    sort_order: # Don't modify the setting unless you know how it works
 
 # dark mode
 darkmode:

--- a/layout/includes/anzhiyu/console.pug
+++ b/layout/includes/anzhiyu/console.pug
@@ -18,12 +18,12 @@
           else 
             .author-content-item-tips 兴趣点
             span.author-content-item-title 寻找你感兴趣的领域
-            !=partial('includes/widget/card_tags', {}, {cache: true})
+            !=partial('includes/widget/card_console_tags', {}, {cache: true})
       .console-card.history
         .item-headline
           i.anzhiyufont.anzhiyu-icon-box-archiv
           span 文章
-        !=partial('includes/widget/card_archives', {}, {cache: true})
+        !=partial('includes/widget/card_console_archives', {}, {cache: true})
   .button-group
     .console-btn-item
       a.darkmode_switchbutton(title='显示模式切换', href='javascript:void(0);')

--- a/layout/includes/anzhiyu/console.pug
+++ b/layout/includes/anzhiyu/console.pug
@@ -9,11 +9,10 @@
   .console-card-group
     .console-card-group-left
       !=partial('includes/widget/card_newest_comment', {}, {cache: true})
-    - const nav_console_music_enable = theme.nav_music.console_widescreen_music
     .console-card-group-right
       .console-card.tags
         .card-content
-          if nav_console_music_enable
+          if theme.nav_music.enable && theme.nav_music.console_widescreen_music
             .author-content-item-tips 音乐
             span.author-content-item-title 灵魂的碰撞💥
           else 
@@ -35,9 +34,10 @@
     .console-btn-item.on#consoleCommentBarrage(onclick='anzhiyu.switchCommentBarrage()', title='热评开关')
       a.commentBarrage
         i.anzhiyufont.anzhiyu-icon-message
-    .console-btn-item#consoleMusic(onclick='anzhiyu.musicToggle()', title='音乐开关')
-      a.music-switch
-        i.anzhiyufont.anzhiyu-icon-music
+    if theme.nav_music.enable
+      .console-btn-item#consoleMusic(onclick='anzhiyu.musicToggle()', title='音乐开关')
+        a.music-switch
+          i.anzhiyufont.anzhiyu-icon-music
     if theme.shortcutKey.enable
       .console-btn-item#consoleKeyboard(onclick='anzhiyu.keyboardToggle()', title='快捷键开关')
         a.keyboard-switch

--- a/layout/includes/header/nav.pug
+++ b/layout/includes/header/nav.pug
@@ -39,7 +39,7 @@ nav#nav
             span=' '+_p('search.title')
       
       input#center-console(type="checkbox")
-      if theme.centerConsole
+      if theme.centerConsole.enable
         label.widget(for="center-console" title=_p("中控台") onclick="anzhiyu.switchConsole();")
           i.left
           i.widget.center

--- a/layout/includes/widget/card_console_archives.pug
+++ b/layout/includes/widget/card_console_archives.pug
@@ -1,0 +1,8 @@
+if theme.centerConsole.card_archives.enable
+  .card-archives
+    - let type = theme.centerConsole.card_archives.type || 'monthly'
+    - let format = theme.centerConsole.card_archives.format || 'MMMM YYYY'
+    - let order = theme.centerConsole.card_archives.order || -1
+    - let limit = theme.centerConsole.card_archives.limit === 0 ? 0 : theme.centerConsole.card_archives.limit || 8
+    != aside_archives({ type:type, format: format, order: order, limit: limit })
+  hr

--- a/layout/includes/widget/card_console_tags.pug
+++ b/layout/includes/widget/card_console_tags.pug
@@ -1,0 +1,10 @@
+if theme.centerConsole.card_tags.enable
+  if site.tags.length
+    .card-tags
+      .item-headline
+      - let tagLimit = theme.centerConsole.card_tags.limit === 0 ? 0 : theme.centerConsole.card_tags.limit || 40
+      if theme.centerConsole.card_tags.color
+        .card-tag-cloud!= cloudTags({source: site.tags, minfontsize: 1.05, maxfontsize: 1.05, limit: tagLimit, unit: 'rem', color: true, highlightTags: theme.centerConsole.card_tags.highlightTags})
+      else
+        .card-tag-cloud!= cloudTags({source: site.tags, minfontsize: 1.05, maxfontsize: 1.05, limit: tagLimit, unit: 'rem', color: false, highlightTags: theme.centerConsole.card_tags.highlightTags})
+    hr


### PR DESCRIPTION
修改内容：
1. 修复 `config-nav_music` 功能未开启时中控台仍然有**音乐开关按钮**，修复中控台右卡片页 `nav_music` 功能未开启时依旧可以显示音乐内容
2. 修复 `config-aside-card_tags/card_archives` 卡片页不开启时，中控台右侧卡片部分留空，新增 `config` 配置和 `widget` ，用于分离 `centerConsole` 和 `aside` 之间的相互影响

复现路径：
1. 将  `config-nav_music-enable` 置 false，中控台依旧可见音乐开关按钮
2. 将  `config-aside-card_tags/card_archives` 置 false， 中控台右侧tag不显示

![Snipaste_2023-10-07_15-22-05](https://github.com/anzhiyu-c/hexo-theme-anzhiyu/assets/73231354/895bf095-19b6-49fb-aeee-6f1bd11710e9)
