### PR TITLE
页脚网页运行时间更改

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -421,6 +421,8 @@ footer:
     work_description: 距离月入25k也就还差一个大佬带我~
     offduty_img: https://npm.elemecdn.com/anzhiyu-blog@2.0.4/img/badge/安知鱼-下班啦.svg
     offduty_description: 下班了就该开开心心的玩耍，嘿嘿~
+    start: # 9
+    end: # 18
   # 徽标部分配置项 https://shields.io/
   # https://img.shields.io/badge/CDN-jsDelivr-orange?style=flat&logo=jsDelivr
   bdageitem:

--- a/layout/includes/footer.pug
+++ b/layout/includes/footer.pug
@@ -47,11 +47,22 @@
     else
       .copyright!= `&copy;${nowYear} By ${config.author}`
 
-  - let work_img = theme.footer.runtime.work_img
-  - let work_description = theme.footer.runtime.work_description
   if theme.footer.runtime.enable
     #workboard
-      img(src=`${work_img}`, alt=`${work_description}`, title=`${work_description}`, class="workSituationImg boardsign")
+      - let work_img = theme.footer.runtime.work_img
+      - let offduty_img = theme.footer.runtime.offduty_img
+      - let work_description = theme.footer.runtime.work_description
+      if work_img != null
+        if offduty_img != null
+          - let work_start = theme.footer.runtime.start || 9;
+          - let work_end = theme.footer.runtime.end || 18;
+          - let cur_hour = new Date().getHours();
+          - let is_work = cur_hour>=work_start&&cur_hour<=work_end
+          - let cur_img = is_work ? theme.footer.runtime.work_img : theme.footer.runtime.offduty_img
+          - let cur_desc = is_work ? theme.footer.runtime.work_description : theme.footer.runtime.offduty_description
+          img(src=`${cur_img}`, alt=`${cur_desc}`, title=`${cur_desc}`, class="workSituationImg boardsign")
+        else
+          img(src=`${work_img}`, alt=`${work_description}`, title=`${work_description}`, class="workSituationImg boardsign")
       #runtimeTextTip
   if theme.footer.custom_text
     .footer_custom_text!=`${theme.footer.custom_text}`


### PR DESCRIPTION
增加允许页脚显示网站运行时间时 `work_img` 不显示
增加 `config-footer-runtime-start/end`配置，默认工作时间9-18点，可自定义，若 `work_img` 和 `offduty_img` 未配置时该时间设定无效