### PR TITLE
增加允许页脚显示网站运行时间时 `work_img` 不显示

### DIFF
--- a/layout/includes/footer.pug
+++ b/layout/includes/footer.pug
@@ -51,7 +51,8 @@
   - let work_description = theme.footer.runtime.work_description
   if theme.footer.runtime.enable
     #workboard
-      img(src=`${work_img}`, alt=`${work_description}`, title=`${work_description}`, class="workSituationImg boardsign")
+      if work_img != null
+        img(src=`${work_img}`, alt=`${work_description}`, title=`${work_description}`, class="workSituationImg boardsign")
       #runtimeTextTip
   if theme.footer.custom_text
     .footer_custom_text!=`${theme.footer.custom_text}`

--- a/layout/includes/third-party/runtime/runtime-js.pug
+++ b/layout/includes/third-party/runtime/runtime-js.pug
@@ -45,9 +45,11 @@ script(async=true).
       } else {
         // 如果是下班时间，插入"安知鱼-下班啦.svg"图片
         let img = document.querySelector("#workboard .workSituationImg");
-        img.src = "#{offduty_img}";
-        img.title = "#{offduty_description}";
-        img.alt = "#{offduty_description}";
+        if (img != null) {
+          img.src = "#{offduty_img}";
+          img.title = "#{offduty_description}";
+          img.alt = "#{offduty_description}";
+        }
 
         currentTimeHtml = `本站居然运行了 ${dnum} 天<span id='runtime'> ${hnum} 小时 ${mnum} 分 ${snum} 秒 </span><i class='anzhiyufont anzhiyu-icon-heartbeat' style='color:red'></i>`;
       }


### PR DESCRIPTION
`config-footer-runtime-work_img` 为空时，保留显示运行时间，而不显示 `work_img` 和 `offduty_img` 图片