### PR TITLE
修复一些问题

### DIFF
--- a/layout/includes/anzhiyu/console.pug
+++ b/layout/includes/anzhiyu/console.pug
@@ -25,15 +25,17 @@
           span 文章
         !=partial('includes/widget/card_console_archives', {}, {cache: true})
   .button-group
-    .console-btn-item
-      a.darkmode_switchbutton(title='显示模式切换', href='javascript:void(0);')
-        i.anzhiyufont.anzhiyu-icon-moon
+    if theme.darkmode.enable
+      .console-btn-item
+        a.darkmode_switchbutton(title='显示模式切换', href='javascript:void(0);')
+          i.anzhiyufont.anzhiyu-icon-moon
     .console-btn-item#consoleHideAside(onclick='anzhiyu.hideAsideBtn()', title='边栏显示控制')
       a.asideSwitch
         i.anzhiyufont.anzhiyu-icon-arrows-left-right
-    .console-btn-item.on#consoleCommentBarrage(onclick='anzhiyu.switchCommentBarrage()', title='热评开关')
-      a.commentBarrage
-        i.anzhiyufont.anzhiyu-icon-message
+    if theme.comment_barrage_config.enable
+      .console-btn-item.on#consoleCommentBarrage(onclick='anzhiyu.switchCommentBarrage()', title='热评开关')
+        a.commentBarrage
+          i.anzhiyufont.anzhiyu-icon-message
     if theme.nav_music.enable
       .console-btn-item#consoleMusic(onclick='anzhiyu.musicToggle()', title='音乐开关')
         a.music-switch

--- a/layout/includes/bbTimeList.pug
+++ b/layout/includes/bbTimeList.pug
@@ -1,15 +1,17 @@
 if site.data.essay
   each i in site.data.essay
     if i.home_essay
+      - let onclick_value = theme.pjax.enable ? `pjax.loadUrl("/essay/");` : '';
+      - let href_value = theme.pjax.enable ? 'javascript:void(0);' : `/essay/`;
       #bbTimeList.bbTimeList.container
-          i.anzhiyufont.anzhiyu-icon-jike.bber-logo.fontbold(onclick=`pjax.loadUrl("/essay/")`,title="即刻短文", aria-hidden="true")
+          a.anzhiyufont.anzhiyu-icon-jike.bber-logo.fontbold(onclick=onclick_value, title="即刻短文", href=href_value, aria-hidden="true")
           #bbtalk.swiper-container.swiper-no-swiping.essay_bar_swiper_container(tabindex="-1")
-            #bber-talk.swiper-wrapper(onclick=`pjax.loadUrl("/essay/")`)
+            #bber-talk.swiper-wrapper(onclick=onclick_value)
               each i in site.data.essay
                 each item, index in i.essay_list
                   if index < 10
                     - var contentText = item.image ? item.content + ' [图片]' : (item.video ? item.content + ' [视频]' : item.content)
-                    .li-style.swiper-slide= contentText
-          i.bber-gotobb.anzhiyufont.anzhiyu-icon-circle-arrow-right( onclick=`pjax.loadUrl("/essay/")`,title="查看全文")
+                    a.li-style.swiper-slide(href=href_value)= contentText
+          a.bber-gotobb.anzhiyufont.anzhiyu-icon-circle-arrow-right( onclick=onclick_value, href=href_value, title="查看全文")
 
       script(src=url_for(theme.home_top.swiper.swiper_js))

--- a/layout/includes/post/ptool.pug
+++ b/layout/includes/post/ptool.pug
@@ -38,6 +38,17 @@ if !theme.disable_top_img && page.top_img !== false
           a.share-button(target='_blank' href=`https://service.weibo.com/share/share.php?title=${site_title}&url=${url}&pic=${bg_img}` rel='external nofollow noreferrer noopener')
             i.anzhiyufont.anzhiyu-icon-weibo
       if theme.ptool.share_copyurl
+        script.
+          function copyCurrentPageUrl() {
+            var currentPageUrl = window.location.href;
+            var input = document.createElement("input");
+            input.setAttribute("value", currentPageUrl);
+            document.body.appendChild(input);
+            input.select();
+            input.setSelectionRange(0, 99999);
+            document.execCommand("copy");
+            document.body.removeChild(input);
+          }
         .share-link.copyurl
-          #post-share-url.share-button(title='复制链接' onclick='rm.copyPageUrl()')
+          #post-share-url.share-button(title='复制链接' onclick='copyCurrentPageUrl()')
             i.anzhiyufont.anzhiyu-icon-link

--- a/scripts/helpers/random.js
+++ b/scripts/helpers/random.js
@@ -1,6 +1,7 @@
 hexo.extend.generator.register("random", function (locals) {
   const config = hexo.config.random || {};
   const themeConfig = hexo.theme.config;
+  const pjaxEn = themeConfig.pjax.enable;
   const randomNumberFriend = themeConfig.footer.list.randomFriends || 0;
   const posts = [];
   const link = locals.data.link || [];
@@ -18,7 +19,9 @@ hexo.extend.generator.register("random", function (locals) {
 
   let result = `var posts=${JSON.stringify(
     posts
-  )};function toRandomPost(){pjax.loadUrl('/'+posts[Math.floor(Math.random() * posts.length)]);};`;
+  )};function toRandomPost(){
+    ${pjaxEn ? "pjax.loadUrl('/'+posts[Math.floor(Math.random() * posts.length)]);" : "window.location.href='/'+posts[Math.floor(Math.random() * posts.length)];"}
+  };`;
 
   if (themeConfig.footer.list.enable && randomNumberFriend > 0) {
     result += `var friend_link_list=${JSON.stringify(link_list)};


### PR DESCRIPTION
Bug：
1. 修复 `config-pjax` 未开启时，随机文章跳转失效。
2. 修复 `config-darkmode` 和 `config-comment_barrage_config` 未开启时，中控台控制对应功能按钮依旧存在。
3. 修复 `config-pjax` 未开启时，首页即刻短文无法跳转的问题。
4. 修复 `config - rightClickMenu` 右键菜单未开启时，`config - ptool - share_copyurl` 无效的问题

复现路径：
1. `config - pjax - enable` 设置为 false 时，主页和右键等随机逛逛相关功能均失效。
2. `config - darkmode - enable` 及  `config - comment_barrage_config - enable` 设置为 false 时，中控台依旧可见显示模式切换按钮及热评开关按钮。 
3.  `config - pjax - enable` 设置为 false 时，首页即刻短文无法跳转至 **essay**。
4. [issues-122](https://github.com/anzhiyu-c/hexo-theme-anzhiyu/issues/122)