### PR TITLE
友链页面的“钓鱼”功能，在主题设置中的朋友圈功能未开启时仍然显示，实际无作用，影响功能美观；现将其在此情况下隐藏

### DIFF
--- a/layout/includes/page/flink.pug
+++ b/layout/includes/page/flink.pug
@@ -36,15 +36,16 @@
                       img.no-lightbox(title=evenNum[index].name, src=url_for(evenNumAvatar + hundredSuffix) onerror=`this.onerror=null;this.src='` + url_for(theme.error_img.flink) + `'` alt=evenNum[index].name)
                     a.tags-group-icon.no-text-decoration(href=url_for(oddNum[index].link), title=oddNum[index].name)
                       img.no-lightbox(title=oddNum[index].name, src=url_for(oddNumAvatar + hundredSuffix) onerror=`this.onerror=null;this.src='` + url_for(theme.error_img.flink) + `'` alt=oddNum[index].name)
-  .title-h2-a
-    .title-h2-a-left
-      h2(style='padding-top:0;margin:.6rem 0 .6rem') 🎣 钓鱼
-      a.random-post-start.no-text-decoration(href='javascript:fetchRandomPost();')
-        i.anzhiyufont.anzhiyu-icon-arrow-rotate-right
-    .title-h2-a-right
-      a.random-post-all.no-text-decoration(href='/link/') 全部友链
-  #random-post
-  script(defer data-pjax src=url_for(theme.asset.random_friends_post_js))
+  if theme.friends_vue && theme.friends_vue.enable
+    .title-h2-a
+      .title-h2-a-left
+        h2(style='padding-top:0;margin:.6rem 0 .6rem') 🎣 钓鱼
+        a.random-post-start.no-text-decoration(href='javascript:fetchRandomPost();')
+          i.anzhiyufont.anzhiyu-icon-arrow-rotate-right
+      .title-h2-a-right
+        a.random-post-all.no-text-decoration(href='/link/') 全部友链
+    #random-post
+    script(defer data-pjax src=url_for(theme.asset.random_friends_post_js))
   
   .flink
     if site.data.link


### PR DESCRIPTION
是这个功能：

![image](https://github.com/anzhiyu-c/hexo-theme-anzhiyu/assets/11372753/c4fd664e-856b-437b-8b8d-2ae6a52da316)

注：我这边的 `dev` 分支与这边同步，本次提交的 pull request 也是在 `dev` 分支上的；而 `main` 分支是基于我自己的需求魔改的，不用理会。