### PR TITLE
优化顶部分类条在条目较少时上下不对齐的情况

### DIFF
--- a/source/css/_extra/catalog_list/catalog_list.css
+++ b/source/css/_extra/catalog_list/catalog_list.css
@@ -20,7 +20,7 @@
   /* 分类/标签较少时，可以选择不设置 width，居中显示 catalog-list-item */
   display: flex;
   white-space: nowrap;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 #catalog-list::-webkit-scrollbar {


### PR DESCRIPTION
在分类较少时，设置 overflow-x: scroll; 会默认保留底部滚动条的高度，给人一种未对齐的感觉。

![before](https://img2.imgtp.com/2024/04/26/YJ0jTeJC.png)

设置为 overflow-x: auto; 后就不存在这个问题了。