### PR TITLE
fix:修复首次为dark时右键菜单文本内容错误的问题

### DIFF
--- a/source/js/main.js
+++ b/source/js/main.js
@@ -1714,6 +1714,9 @@ document.addEventListener("DOMContentLoaded", function () {
       executeShortcutKeyFunction();
     }
     if (GLOBAL_CONFIG.autoDarkmode) {
+      const mode = document.documentElement.getAttribute('data-theme');
+      const menuDarkmodeText = $rightMenu.querySelector(".menu-darkmode-text");
+      menuDarkmodeText.textContent = mode === "light" ? "深色模式" : "浅色模式";
       window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", e => {
         if (saveToLocal.get("theme") !== undefined) return;
         e.matches ? handleThemeChange("dark") : handleThemeChange("light");


### PR DESCRIPTION
【问题描述】设备或浏览器外观为深色模式下，主题也为深色模式，而右键菜单中的内容为“深色模式”而非“浅色模式”，如下图所示。
![image](https://github.com/user-attachments/assets/0f5170e8-a38a-46b1-9753-06ae1fa1624d)
