### PR TITLE
fix:修复首次为dark时右键菜单文本内容错误的问题

### DIFF
--- a/source/js/main.js
+++ b/source/js/main.js
@@ -176,6 +176,14 @@ document.addEventListener("DOMContentLoaded", function () {
     $nav.classList.toggle("hide-menu", hideMenuIndex);
   };
 
+  // 初始化右键菜单文本
+  const initRightMenu = () => {
+    $rightMenu = document.getElementById("rightMenu");
+    const mode = document.documentElement.getAttribute('data-theme');
+    const menuDarkmodeText = $rightMenu.querySelector(".menu-darkmode-text");
+    menuDarkmodeText.textContent = mode === "light" ? "深色模式" : "浅色模式";
+  }
+  
   // 初始化header
   const initAdjust = () => {
     adjustMenu(true);
@@ -1808,6 +1816,7 @@ document.addEventListener("DOMContentLoaded", function () {
     }, 200);
   };
 
+  initRightMenu();
   refreshFn();
   unRefreshFn();
 });


### PR DESCRIPTION
【问题描述】初始状态为 dark 时，右键菜单文本内容为“深色模式”，预期为“浅色模式”，如下图所示。
![image](https://github.com/user-attachments/assets/8b9eae75-8e83-49fa-a23c-c4879dc1b5b2)



【解决方式】在 dom  完成加载后通过 `getAttribute('data-theme')` 更新文本。