### PR TITLE
fix: 修复即刻短文界面文本换行错误

### DIFF
--- a/source/css/_extra/essay_page/essay_page.css
+++ b/source/css/_extra/essay_page/essay_page.css
@@ -75,6 +75,7 @@ body[data-type="essay"] #web_bg {
   display: flex;
   flex-direction: column;
   text-align: justify;
+  word-break: break-all;
 }
 #bber p {
   margin: 0px;


### PR DESCRIPTION
如题，未修复前的BUG复现截图：

![图片](https://github.com/user-attachments/assets/5c17f7ff-414b-421b-acba-44ee262e1df1)

可以看到链接中的文字超出了容器，并且右侧QQ音乐那个链接，文本出现了分散的情况。

修复后的效果为：

![图片](https://github.com/user-attachments/assets/b6c8622c-e830-456f-8b91-7f991700905d)
