### PR TITLE
feat: add colorthief support to get the main color of the image

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -193,7 +193,7 @@ post_meta:
 # 主色调相关配置
 mainTone:
   enable: false # true or false 文章是否启用获取图片主色调
-  mode: api # cdn/api/both cdn模式为图片url+imageAve参数获取主色调，api模式为请求API获取主色调，both模式会先请求cdn参数，无法获取的情况下将请求API获取，可以在文章内配置main_color: '#3e5658'，使用十六进制颜色，则不会请求both/cdn/api获取主色调，而是直接使用配置的颜色
+  mode: api # colorthief/cdn/api/both colorthief模式为前端获取图片主色调，cdn模式为图片url+imageAve参数获取主色调，api模式为请求API获取主色调，both模式会先请求cdn参数，无法获取的情况下将请求API获取，可以在文章内配置main_color: '#3e5658'，使用十六进制颜色，则不会请求colorthief/cdn/api/both获取主色调，而是直接使用配置的颜色
   # 项目地址：https://github.com/anzhiyu-c/img2color-go
   api: https://img2color-go.vercel.app/api?img= # mode为api时可填写
   cover_change: true # 整篇文章跟随cover修改主色调
@@ -1330,3 +1330,4 @@ CDN:
     # waterfall:
     # ali_iconfont_css:
     # accesskey_js:
+    # colorthief:

--- a/layout/includes/additional-js.pug
+++ b/layout/includes/additional-js.pug
@@ -49,8 +49,9 @@ div
   else if theme.local_search.enable
     script(src=url_for(theme.asset.local_search))
 
-
-
+  //- colorthief
+  if theme.mainTone.mode === "colorthief"
+    script(src=url_for(theme.asset.colorthief))
 
   .js-pjax
     if theme.peoplecanvas.enable && is_home()

--- a/plugins.yml
+++ b/plugins.yml
@@ -230,5 +230,5 @@ accesskey_js:
   version: 1.1.5
 colorthief:
   name: colorthief
-  file: dist/color-thief.umd.js
+  file: dist/color-thief.umd.min.js
   version: 2.6.0

--- a/plugins.yml
+++ b/plugins.yml
@@ -228,3 +228,7 @@ accesskey_js:
   name: anzhiyu-theme-static
   file: accesskey/accesskey.js
   version: 1.1.5
+colorthief:
+  name: colorthief
+  file: dist/color-thief.umd.js
+  version: 2.6.0

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -1218,7 +1218,8 @@ document.addEventListener("DOMContentLoaded", function () {
   //封面纯色
   const coverColor = async () => {
     const root = document.querySelector(":root");
-    const path = document.getElementById("post-top-bg")?.src;
+    const bg = document.getElementById("post-top-bg")
+    const path = bg?.src;
     if (!path) {
       // 非文章情况，直接设置不需要请求了
       root.style.setProperty("--anzhiyu-bar-background", "var(--anzhiyu-meta-theme-color)");
@@ -1267,6 +1268,39 @@ document.addEventListener("DOMContentLoaded", function () {
             getComputedStyle(document.documentElement).getPropertyValue("--anzhiyu-main") + "dd"
           );
         }
+      } else if (GLOBAL_CONFIG.mainTone.mode == "colorthief") {
+        const colorThief = new ColorThief();
+        bg.crossOrigin = "Anonymous";
+        const getColorFromImage = () => {
+          const rgb = colorThief.getColor(bg);
+          let value = colorHex(`rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`);
+          if (getContrastYIQ(value) === "light") {
+            value = LightenDarkenColor(value, -40);
+          } else {
+            value = LightenDarkenColor(value, 40);
+          }
+          root.style.setProperty("--anzhiyu-bar-background", value);
+          requestAnimationFrame(() => {
+            anzhiyu.initThemeColor();
+          });
+          if (GLOBAL_CONFIG.mainTone.cover_change) {
+            document.documentElement.style.setProperty("--anzhiyu-main", value);
+            document.documentElement.style.setProperty(
+              "--anzhiyu-theme-op",
+              getComputedStyle(document.documentElement).getPropertyValue(
+                "--anzhiyu-main"
+              ) + "23"
+            );
+            document.documentElement.style.setProperty(
+              "--anzhiyu-theme-op-deep",
+              getComputedStyle(document.documentElement).getPropertyValue(
+                "--anzhiyu-main"
+              ) + "dd"
+            );
+          }
+          bg.removeEventListener("load", getColorFromImage);
+        };
+        bg.addEventListener("load", getColorFromImage);
       } else {
         const fallbackValue = "var(--anzhiyu-theme)";
         let fetchPath = "";


### PR DESCRIPTION
**新增功能**  
   - 引入 `colorthief`，支持在前端提取图片的主色调，无需使用 `img2color-go`。  
   - 更新主色调配置，新增 `colorthief` 模式，并在相关文件中完成引入。

**注意事项**  
   - `colorthief` 使用 `canvas` 方法提取图片主色调，但不支持跨域图片。为解决此问题，当启用 `colorthief` 模式时，会自动为图片添加 `crossOrigin` 属性以确保正常运行。  
   - 测试发现 `npm.elemecdn.com` CDN 不包含 `colorthief` 的文件资源。如果需要使用该功能，可能需要更换包含 `colorthief` 的 NPM CDN，或手动在配置文件中指定其文件地址。  

**相关地址**  
   - GitHub: https://github.com/lokesh/color-thief
   - NPM: https://www.npmjs.com/package/colorthief
   - CdnJs: https://cdnjs.com/libraries/color-thief
