### PR TITLE
feat(highlight): support shiki

### DIFF
--- a/layout/includes/head/config.pug
+++ b/layout/includes/head/config.pug
@@ -81,7 +81,7 @@
 
   let highlight = 'undefined';
   let syntaxHighlighter = config.syntax_highlighter;
-  let highlightEnable = syntaxHighlighter ? ['highlight.js', 'prismjs'].includes(syntaxHighlighter) : (config.highlight.enable || config.prismjs.enable);
+  let highlightEnable = syntaxHighlighter ? ['highlight.js', 'prismjs', 'shiki'].includes(syntaxHighlighter) : (config.highlight.enable || config.prismjs.enable);
   if (highlightEnable) {
     highlight = JSON.stringify({
       plugin: syntaxHighlighter ? syntaxHighlighter : config.highlight.enable ? 'highlight.js' : 'prismjs',

--- a/scripts/events/stylus.js
+++ b/scripts/events/stylus.js
@@ -11,7 +11,7 @@ hexo.extend.filter.register("stylus:renderer", style => {
 
   // for hexo > 7.0
   if (syntaxHighlighter) {
-    highlightEnable = syntaxHighlighter === "highlight.js";
+    highlightEnable = syntaxHighlighter === "highlight.js" || syntaxHighlighter === "shiki";
     prismjsEnable = syntaxHighlighter === "prismjs";
   }
 

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -228,7 +228,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const isHighlightShrink = GLOBAL_CONFIG_SITE.isHighlightShrink;
     const isShowTool = highlightCopy || highlightLang || isHighlightShrink !== undefined;
     const $figureHighlight =
-      plugin === "highlight.js"
+       ["highlight.js", "shiki"].includes(plugin)
         ? document.querySelectorAll("figure.highlight")
         : document.querySelectorAll('pre[class*="language-"]');
 


### PR DESCRIPTION
支持使用 shiki 代码高亮器，能比默认的 highlight.js、prismjs 提供更好的代码高亮效果，使用插件：https://github.com/HPCesia/hexo-highlighter-shiki

## 安装：

```shell
pnpm add hexo-highlighter-shiki
```

## 配置：

建议先删除其他的代码高亮器，然后仅定义以下内容：

```yaml
# _config.yml
syntax_highlighter: shiki

shiki:
  line_number: true
  pre_style: false # 不关闭会有代码背景
```

更多配置：https://github.com/HPCesia/hexo-highlighter-shiki
